### PR TITLE
Adds docker builds configuration, workflow and bootstrapper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+﻿### VisualStudioCode template
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,85 @@
+﻿name: Build & Publish Docker Image
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  push:
+    branches: [ master ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
+        with:
+          cosign-release: 'v1.4.0'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 
 RUN apt-get update \
-  && apt-get install -y \
-    dos2unix
-
+  && apt-get install -y dos2unix
 
 WORKDIR /build
 
@@ -20,14 +18,24 @@ COPY ian.sh ian.sh
 RUN dos2unix ian.sh
 
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS app
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS app
+
+RUN apk update && apk add --no-cache \
+  ca-certificates \
+  gcompat \
+  icu-libs
 
 COPY --from=build /app /app
-COPY --from=build /build/ian.sh ian.sh
+COPY --from=build /build/ian.sh /app/ian.sh
+
+WORKDIR /app
 
 EXPOSE 1212/tcp
 EXPOSE 1212/udp
 
+ENV ASPNETCORE_URLS=http://+:5000
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
 VOLUME ["/app/instances", "/app_config"]
 
-ENTRYPOINT ["./ian.sh"]
+ENTRYPOINT ["/bin/sh", "./ian.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 
+RUN apt-get update \
+  && apt-get install -y \
+    dos2unix
+
+
 WORKDIR /build
 COPY SS14.Watchdog/ .
 RUN dotnet restore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+
+WORKDIR /build
+COPY SS14.Watchdog/ .
+RUN dotnet restore
+RUN dotnet publish -c Release -r linux-x64 --no-self-contained
+RUN cp -R bin/Release/net6.0/linux-x64/publish /app
+RUN cp appsettings.Development.yml /app/appsettings.yml
+
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS app
+COPY --from=build /app /app
+COPY ian.sh ian.sh
+
+RUN dos2unix ian.sh
+
+EXPOSE 1212/tcp
+EXPOSE 1212/udp
+
+VOLUME ["/app/instances", "/app_config"]
+
+ENTRYPOINT ["./ian.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,24 @@ RUN apt-get update \
 
 
 WORKDIR /build
+
 COPY SS14.Watchdog/ .
+
 RUN dotnet restore
+
 RUN dotnet publish -c Release -r linux-x64 --no-self-contained
+
 RUN cp -R bin/Release/net6.0/linux-x64/publish /app
 RUN cp appsettings.Development.yml /app/appsettings.yml
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS app
-COPY --from=build /app /app
 COPY ian.sh ian.sh
-
 RUN dos2unix ian.sh
+
+
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS app
+
+COPY --from=build /app /app
+COPY --from=build /build/ian.sh ian.sh
 
 EXPOSE 1212/tcp
 EXPOSE 1212/udp

--- a/ian.sh
+++ b/ian.sh
@@ -3,7 +3,15 @@ CONFIG_VOLUME="/app_config/appsettings.yml"
 # App config in volatile storage
 CONFIG_TARGET="/app/appsettings.yml"
 
-echo "
+# The things Ian can say
+IAN_NOISES=("Woof" "Bork" "Bark" "Wau" "Ruff" "Hau Hau" "Awroo")
+# Random number from 0 to 32767
+RANDOM=$$$(date +%s)
+DOG_NOISE=${IAN_NOISES[$RANDOM % ${#RANDOM[@]}]}
+
+bs_print () { echo "[IAN BOOTSTRAP] "$@"" }
+
+bs_print "
 ######\  ######\  ##\   ##\ 
 \_##  _|##  __##\ ###\  ## |
   ## |  ## /  ## |####\ ## |   The Nanotrasen approved
@@ -15,24 +23,24 @@ echo "
 "
 
 if [ ! -f "$CONFIG_VOLUME" ]; then
-  echo "Daemon configuration not found, copying from deployment..."
+  bs_print "Daemon configuration not found, copying from deployment..."
   # Copy fresh config to mount
   cp $CONFIG_TARGET $CONFIG_VOLUME
 fi
 
 # Delete the fresh config
-echo "Wiping volatile config..."
+bs_print "Wiping volatile config..."
 rm $CONFIG_TARGET
 
 # Symlink the real config to the app dir
-echo "Linking mounted config to watchdog..."
+bs_print "Linking mounted config to watchdog..."
 ln -vsf $CONFIG_VOLUME $CONFIG_TARGET
 
 # Check if we succeeded with creating the link
 if [ ! -f "$CONFIG_TARGET" ]; then
-  echo "Failed to create symlink for config!"
+  bs_print "Failed to create symlink for config!"
   exit 1
 fi
 
-echo "Handing over to Ian!"
+bs_print "Handing over to Ian! $DOG_NOISE"
 exec ./SS14.Watchdog "$@"

--- a/ian.sh
+++ b/ian.sh
@@ -23,12 +23,12 @@ echo "
 if [ ! -f "$CONFIG_VOLUME" ]; then
   bs_print "Daemon configuration not found, copying from deployment..."
   # Copy fresh config to mount
-  cp $CONFIG_TARGET $CONFIG_VOLUME
+  cp -v $CONFIG_TARGET $CONFIG_VOLUME
 fi
 
 # Delete the fresh config
 bs_print "Wiping volatile config..."
-rm $CONFIG_TARGET
+rm -v $CONFIG_TARGET
 
 # Symlink the real config to the app dir
 bs_print "Linking mounted config to watchdog..."

--- a/ian.sh
+++ b/ian.sh
@@ -32,4 +32,4 @@ if [ ! -f "$CONFIG_TARGET" ]; then
   exit 1
 fi
 
-exec ./SS14.Watchdog/
+exec ./SS14.Watchdog $@

--- a/ian.sh
+++ b/ian.sh
@@ -3,23 +3,21 @@ CONFIG_VOLUME="/app_config/appsettings.yml"
 # App config in volatile storage
 CONFIG_TARGET="/app/appsettings.yml"
 
-# The things Ian can say
-IAN_NOISES=("Woof" "Bork" "Bark" "Wau" "Ruff" "Hau Hau" "Awroo")
-# Random number from 0 to 32767
-RANDOM=$$$(date +%s)
-DOG_NOISE=${IAN_NOISES[$RANDOM % ${#RANDOM[@]}]}
+# The things Ian can say, one will be picked at random
+IAN_NOISE=`echo "Woof Bork Bark Wau Ruff Hauhau Awroo" |
+  awk 'BEGIN { srand() } {split($0,a); a[1+int(rand()*length(a))]}'`
 
-bs_print () { echo "[IAN BOOTSTRAP] "$@"" }
+bs_print () { echo "[IAN BOOTSTRAP] ""$@"""; }
 
-bs_print "
-######\  ######\  ##\   ##\ 
-\_##  _|##  __##\ ###\  ## |
-  ## |  ## /  ## |####\ ## |   The Nanotrasen approved
-  ## |  ######## |## ##\## |        Space Station 14
-  ## |  ##  __## |## \#### |      Watchdog
-  ## |  ## |  ## |## |\### |
-######\ ## |  ## |## | \## |   Horizon Container Edition
-\______|\__|  \__|\__|  \__|
+echo "
+  ######\  ######\  ##\   ##\ 
+  \_##  _|##  __##\ ###\  ## |
+    ## |  ## /  ## |####\ ## |   The Nanotrasen approved
+    ## |  ######## |## ##\## |        Space Station 14
+    ## |  ##  __## |## \#### |      Watchdog
+    ## |  ## |  ## |## |\### |
+  ######\ ## |  ## |## | \## |   Horizon Container Edition
+  \______|\__|  \__|\__|  \__|
 "
 
 if [ ! -f "$CONFIG_VOLUME" ]; then
@@ -42,5 +40,5 @@ if [ ! -f "$CONFIG_TARGET" ]; then
   exit 1
 fi
 
-bs_print "Handing over to Ian! $DOG_NOISE"
+bs_print "Handing over to Ian! $IAN_NOISE"
 exec ./SS14.Watchdog "$@"

--- a/ian.sh
+++ b/ian.sh
@@ -7,9 +7,9 @@ CONFIG_TARGET="/app/appsettings.yml"
 IAN_NOISE=`echo "Woof Bork Bark Wau Ruff Hauhau Awroo" |
   awk 'BEGIN { srand() } {split($0,a); print a[1+int(rand()*length(a))]}'`
 
-bs_print () { echo "[IAN BOOTSTRAP] ""$@"""; }
+bs_print () { printf '%s\n' "[IAN BOOTSTRAP] ""$@"""; }
 
-echo "
+printf '%s\n' "
   ######\  ######\  ##\   ##\ 
   \_##  _|##  __##\ ###\  ## |
     ## |  ## /  ## |####\ ## |   The Nanotrasen approved
@@ -40,5 +40,5 @@ if [ ! -f "$CONFIG_TARGET" ]; then
   exit 1
 fi
 
-bs_print "Handing over to Ian! $IAN_NOISE!\n"
+bs_print "Handing over to Ian! $IAN_NOISE!" ''
 exec ./SS14.Watchdog "$@"

--- a/ian.sh
+++ b/ian.sh
@@ -28,7 +28,7 @@ fi
 
 # Delete the fresh config
 bs_print "Wiping volatile config..."
-rm -v $CONFIG_TARGET
+rm -vf $CONFIG_TARGET
 
 # Symlink the real config to the app dir
 bs_print "Linking mounted config to watchdog..."

--- a/ian.sh
+++ b/ian.sh
@@ -5,7 +5,7 @@ CONFIG_TARGET="/app/appsettings.yml"
 
 # The things Ian can say, one will be picked at random
 IAN_NOISE=`echo "Woof Bork Bark Wau Ruff Hauhau Awroo" |
-  awk 'BEGIN { srand() } {split($0,a); a[1+int(rand()*length(a))]}'`
+  awk 'BEGIN { srand() } {split($0,a); print a[1+int(rand()*length(a))]}'`
 
 bs_print () { echo "[IAN BOOTSTRAP] ""$@"""; }
 

--- a/ian.sh
+++ b/ian.sh
@@ -1,0 +1,35 @@
+﻿# App config in container volume
+CONFIG_VOLUME="/app_config/appsettings.yml"
+# App config in volatile storage
+CONFIG_TARGET="/app/appsettings.yml"
+
+echo "
+######\  ######\  ##\   ##\ 
+\_##  _|##  __##\ ###\  ## |
+  ## |  ## /  ## |####\ ## |   The Nanotrasen approved
+  ## |  ######## |## ##\## |        Space Station 14
+  ## |  ##  __## |## \#### |      Watchdog
+  ## |  ## |  ## |## |\### |
+######\ ## |  ## |## | \## |   Horizon Container Edition
+\______|\__|  \__|\__|  \__|
+"
+
+if [ ! -f "$CONFIG_VOLUME" ]; then
+  echo "daemon configuration not found, copying from deployment"
+  # Copy fresh config to mount
+  cp $CONFIG_TARGET $CONFIG_VOLUME
+fi
+
+# Delete the fresh config
+rm $CONFIG_TARGET
+
+# Symlink the real config to the app dir
+ln -vsf $CONFIG_VOLUME $CONFIG_TARGET
+
+# Check if we succeeded with creating the link
+if [ ! -f "$CONFIG_TARGET" ]; then
+  echo "failed to create symlink for config!"
+  exit 1
+fi
+
+exec ./SS14.Watchdog/

--- a/ian.sh
+++ b/ian.sh
@@ -1,4 +1,4 @@
-﻿# App config in container volume
+# App config in container volume
 CONFIG_VOLUME="/app_config/appsettings.yml"
 # App config in volatile storage
 CONFIG_TARGET="/app/appsettings.yml"
@@ -32,4 +32,4 @@ if [ ! -f "$CONFIG_TARGET" ]; then
   exit 1
 fi
 
-exec ./SS14.Watchdog $@
+exec ./SS14.Watchdog "$@"

--- a/ian.sh
+++ b/ian.sh
@@ -15,21 +15,24 @@ echo "
 "
 
 if [ ! -f "$CONFIG_VOLUME" ]; then
-  echo "daemon configuration not found, copying from deployment"
+  echo "Daemon configuration not found, copying from deployment..."
   # Copy fresh config to mount
   cp $CONFIG_TARGET $CONFIG_VOLUME
 fi
 
 # Delete the fresh config
+echo "Wiping volatile config..."
 rm $CONFIG_TARGET
 
 # Symlink the real config to the app dir
+echo "Linking mounted config to watchdog..."
 ln -vsf $CONFIG_VOLUME $CONFIG_TARGET
 
 # Check if we succeeded with creating the link
 if [ ! -f "$CONFIG_TARGET" ]; then
-  echo "failed to create symlink for config!"
+  echo "Failed to create symlink for config!"
   exit 1
 fi
 
+echo "Handing over to Ian!"
 exec ./SS14.Watchdog "$@"

--- a/ian.sh
+++ b/ian.sh
@@ -40,5 +40,5 @@ if [ ! -f "$CONFIG_TARGET" ]; then
   exit 1
 fi
 
-bs_print "Handing over to Ian! $IAN_NOISE"
+bs_print "Handing over to Ian! $IAN_NOISE!\n"
 exec ./SS14.Watchdog "$@"


### PR DESCRIPTION
Adds Docker build file that builds the image on debian bullseye-slim, with a runtime image created on alpine-3.14
Bootstrap links instances and configuration to volumes for persistent storage.
Initial configuration however is volatile as the default config currently points to `./bin/instances`, which should be fine though for quick tests.

Workflow builds it with the above file and publishes it to the GHCR.

The bootstrap also barks at the handover to the watchdog :)