### PR TITLE
Fix docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,4 +82,4 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+        run: cosign sign ${{ env.REGISTRY }}/${${{ env.LOWERCASE_IMAGE_NAME }},,}@${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
Apparnetly the github container registry only works with lowercase names.
The template workflow used doesn't bother with that.
So obviously cosign can't access it.

This fixes that by lowercasing the image_name.